### PR TITLE
Fix exception on pickle.dump into ZstdFile (#4)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -456,10 +456,18 @@ class ZstdFile(_compression.BaseStream):
         may not reflect the data written until close() is called.
         """
         self._check_can_write()
+
+        if isinstance(data, bytes):
+            size = len(data)
+
+        else:
+            data = memoryview(data)
+            size = data.nbytes
+
         compressed = self._compressor.compress(data)
         self._fp.write(compressed)
-        self._pos += len(data)
-        return len(data)
+        self._pos += size
+        return size
 
     def seek(self, offset, whence=io.SEEK_SET):
         """Change the file position.

--- a/tests/test_zstd.py
+++ b/tests/test_zstd.py
@@ -6,6 +6,7 @@ import io
 import os
 import re
 import sys
+import array
 import pathlib
 import pickle
 import random
@@ -2724,6 +2725,12 @@ class OpenTestCase(unittest.TestCase):
             dat = f.read()
 
         self.assertEqual(dat, SAMPLES[0])
+
+    def test_pickle_buffer(self):
+        arr = array.array("i", range(1_000_000))
+
+        with open(BytesIO(), "wb") as f:
+            pickle.dump(pickle.PickleBuffer(arr), f, protocol=5)
 
 class StreamFunctionsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Recently, I opened an issue about this problem (issue #4)

It turns out that the solution was to check if the data is `bytes` and, if not, to convert it to a `memoryview`.
I took the idea from [python's gzip.GzipFile](https://github.com/python/cpython/blob/de367378f67d7e90e4015100b19277685a3c9bb3/Lib/gzip.py#L281).

In addition, I created a test case to check for this problem.
I had to forcefully convert a python array to a PickleBuffer to avoiding adding extra requirements (such as pandas ou numpy).